### PR TITLE
Add step to check branch

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -12,11 +12,11 @@ variables:
 jobs:
   - job: Publish
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: "vs2017-win2016"
     steps:
       - script: |
           choco install DocFX
-        displayName: 'Install DocFX'
+        displayName: "Install DocFX"
 
       - script: |
           echo "Clone source"
@@ -50,7 +50,7 @@ jobs:
           mv .\_site $(Build.ArtifactStagingDirectory)\_site
           git clean -fd
           rmdir V1\main /s /q
-          
+
           echo "Check out gh-pages branch"
           git checkout gh-pages        
           git rm *
@@ -58,6 +58,10 @@ jobs:
           echo "Copy DocFX output into branch"
           Xcopy /E /I $(Build.ArtifactStagingDirectory)\_site\* .
           rmdir obj /s /q
+
+          echo "Check branch"
+          for /f %%i in ('git branch --show-current') do set BRANCH=%%i
+          if not %BRANCH%==gh-pages exit /b 1
 
           echo "Stage changes"
           git add .        
@@ -72,4 +76,4 @@ jobs:
 
           echo "Complete!"
         workingDirectory: 'C:\'
-        displayName: 'Publish DocFX'
+        displayName: "Publish DocFX"

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -52,21 +52,20 @@ jobs:
           rmdir V1\main /s /q
 
           echo "Check out gh-pages branch"
-          git checkout gh-pages        
-          git rm *
-
-          echo "Copy DocFX output into branch"
-          Xcopy /E /I $(Build.ArtifactStagingDirectory)\_site\* .
-          rmdir obj /s /q
+          git checkout gh-pages
 
           echo "Check branch"
           for /f %%i in ('git branch --show-current') do set BRANCH=%%i
           if not %BRANCH%==gh-pages exit /b 1
+          git branch
+
+          echo "Copy DocFX output into branch"
+          git rm *
+          Xcopy /E /I $(Build.ArtifactStagingDirectory)\_site\* .
+          rmdir obj /s /q
 
           echo "Stage changes"
-          git add .        
-          git checkout gh-pages 
-          git branch
+          git add .
 
           echo "Commit changes"
           git commit -m "Build Agent Modified DocFX Site"


### PR DESCRIPTION
Suggest adding lines 57-59 to all docfx azure-pipeline.yml files. These lines check the current branch before committing changes and make sure the pipeline is on the correct branch. This should prevent the issue we've seen a few times where the master branch gets overwritten by output from the docfx build. Typically what seems to happen is it fails to check out the gh-pages branch, so it stays on the master branch, and then checks in the output of the docfx build to the master branch. With this check the script will exit if it's not on the gh-pages branch.