### PR TITLE
Updated StartTime/EndTime Parameter descriptions

### DIFF
--- a/content/main/shared-content/configuration/history-recovery/on-demand-history-recovery-configuration.md
+++ b/content/main/shared-content/configuration/history-recovery/on-demand-history-recovery-configuration.md
@@ -27,8 +27,8 @@ The PI adapter supports performing history recovery on-demand by specifying star
 Parameter | Type| Description
 ---------|----------|---------
  **Id** | `string` | The Id of the history recovery<br><br> **Note:** You cannot run multiple history recoveries with the same Id.
- **StartTime** | `datetime` | Time when the the first data items are collected.<br><br> **Note:** Timestamps are interpreted into the Coordinated Universal Time (UTC) time standard.   
- **EndTime** | `datetime`| Time when the last data items are collected.<br><br> **Note:** Timestamps are interpreted into the Coordinated Universal Time (UTC) time standard.
+ **StartTime** | `datetime` | Time when the first data items are collected.<br><br> **Note:** Timestamps are interpreted into the Coordinated Universal Time (UTC) time standard. OSIsoft recommends the following format for entering a startTime in a curl command: *YYYY-MM-DD*T*HH:MM:SS*Z.   
+ **EndTime** | `datetime`| Time when the last data items are collected.<br><br> **Note:** Timestamps are interpreted into the Coordinated Universal Time (UTC) time standard. OSIsoft recommends the following format for entering a endTime in a curl command: *YYYY-MM-DD*T*HH:MM:SS*Z.
 | **Checkpoint** | `datetime` | The latest timestamp that the history recovery has completed with the range being between **startTime** and **endTime**.
 | **Items** | `double` | The amount of data selection items in the history recovery operation.
 | **RecoveredEvents** | `double` | Number of events that the history recovery found on the data source.

--- a/content/main/shared-content/configuration/history-recovery/on-demand-history-recovery-configuration.md
+++ b/content/main/shared-content/configuration/history-recovery/on-demand-history-recovery-configuration.md
@@ -27,8 +27,8 @@ The PI adapter supports performing history recovery on-demand by specifying star
 Parameter | Type| Description
 ---------|----------|---------
  **Id** | `string` | The Id of the history recovery<br><br> **Note:** You cannot run multiple history recoveries with the same Id.
- **StartTime** | `datetime` | Time when the the first data items are collected.
- **EndTime** | `datetime`| Time when the last data items are collected.
+ **StartTime** | `datetime` | Time when the the first data items are collected.<br><br> **Note:** Timestamps are interpreted into the Coordinated Universal Time (UTC) time standard.   
+ **EndTime** | `datetime`| Time when the last data items are collected.<br><br> **Note:** Timestamps are interpreted into the Coordinated Universal Time (UTC) time standard.
 | **Checkpoint** | `datetime` | The latest timestamp that the history recovery has completed with the range being between **startTime** and **endTime**.
 | **Items** | `double` | The amount of data selection items in the history recovery operation.
 | **RecoveredEvents** | `double` | Number of events that the history recovery found on the data source.


### PR DESCRIPTION
_Added a new note to the StartTime and EndTime parameter description to define how these times are interpreted by the adapter. Since the OPC UA adapter only handles UTC for the time being, the note was added for clarification to the customer._ 

Jiyeon, do we need to provide an example on how to translate a time zone into the UTC standard or is it that something that a user will be familiar with? 